### PR TITLE
Revert "Fix pagination to use bigger size and not need more calls"

### DIFF
--- a/y2m
+++ b/y2m
@@ -15,8 +15,9 @@ function get_repos
 {
   for orgname in "$@";
   do
-     # JR if yast oraganization ever have more then 10000 entries I promise to update this number :)
-     curl -s "https://api.github.com/orgs/${orgname}/repos?per_page=10000" | grep "\"name\":" | sed -e "s/^.*name\": \"\(.*\)\",.*$/\1/"
+    for page in 1 2 3 4 5 ; do # workaround for github's silly pagination, max. is 100 per page
+       curl -s "https://api.github.com/orgs/${orgname}/repos?page=${page}&per_page=100" | grep "\"name\":" | sed -e "s/^.*name\": \"\(.*\)\",.*$/\1/"
+    done
   done
 }
 


### PR DESCRIPTION
This reverts commit a2c8ff0cb8b2acc782d99516c88f345309659142.
Conflicts: y2m

A nice idea but the fix was not tested, obviously. The per_page limit is 100 according to github's api documentation. The following command always returns "100" even though we have more than 140 modules:
$ curl -s "https://api.github.com/orgs/yast/repos?per_page=10000" | grep git_url | wc -l
