### PR TITLE
y2m list: filter out license names

### DIFF
--- a/y2m
+++ b/y2m
@@ -220,9 +220,7 @@ get_repos_page() # {{{
   (HTTP/*\ 304\ *) return 2 ;;
   (*) return 22 ;;
   esac
-  # find the "name" properties, except in the "license" subobject
-  sed -n -e '/"license": {/,/}/d;/"name":/s/^.*"name": "\([^"]*\)",.*$/\1/p' $responsefile \
-  | sort \
+  ruby -rjson -e 'JSON.load(ARGF).map{|r| r["name"]}.sort.each{|n| puts n}' $responsefile \
   > $reposfile.tmp
   local rcnt=$(wc -l < $reposfile.tmp)
   mv $reposfile.tmp $reposfile

--- a/y2m
+++ b/y2m
@@ -220,7 +220,8 @@ get_repos_page() # {{{
   (HTTP/*\ 304\ *) return 2 ;;
   (*) return 22 ;;
   esac
-  sed -n -e '/"name":/s/^.*"name": "\([^"]*\)",.*$/\1/p' $responsefile \
+  # find the "name" properties, except in the "license" subobject
+  sed -n -e '/"license": {/,/}/d;/"name":/s/^.*"name": "\([^"]*\)",.*$/\1/p' $responsefile \
   | sort \
   > $reposfile.tmp
   local rcnt=$(wc -l < $reposfile.tmp)


### PR DESCRIPTION
WTF, right?

Recently(?) the GitHub .../repos output was extended with licensing info,
and there is a new "name" field:

```json
[
  {
    "id": 4368067,
    "name": "yast-add-on",                              <=== WANTED name
    "full_name": "yast/yast-add-on",
    "owner": {
      "login": "yast",
      ...
    },
    ...
    "license": {
      "key": "gpl-2.0",
      "name": "GNU General Public License v2.0",        <=== UNWANTED name
      "spdx_id": "GPL-2.0",
      "url": "https://api.github.com/licenses/gpl-2.0"
    },
    ...
  },
  ...
]
```

so we have:

```console
yast-meta$ ./y2m list
Fetching repository names.....
Modules in 'yast':
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 GNU General Public 
License v2.0 GNU General Public License v2.0 GNU General Public License v2.0 
GNU General Public License v2.0 GNU General Public License v2.0 GNU General 
Public License v2.0 GNU General Public License v2.0 Other yast-add-on 
yast-add-on-creator yast-apparmor yast-audit-laf yast-autofs 
yast-autoinstallation yast-backup yast-bluetooth yast-boot-server 
yast-bootloader yast-branding yast-build-test yast-ca-management 
...
```